### PR TITLE
EVEREST-107 Update RC rebuild workflow

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -6,7 +6,7 @@ on:
       - release-[0-9]+.[0-9]+.[0-9]+*
 
 env:
-  NODE_OPTIONS: "—-max_old_space_size=4096"
+  NODE_OPTIONS: "--max_old_space_size=4096"
 
 jobs:
   build:
@@ -41,10 +41,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Install Bit
-        run: | 
-          cd ${GITHUB_WORKSPACE}/percona-everest-frontend
-          make install-bit
+      - name: Install Bit Version Manager
+        run: npm i -g @teambit/bvm
+
+      - name: Install latest Bit version
+        run: bvm install 1.1.0
 
       - name: Add bvm bin folder to path
         run: echo "$HOME/bin" >> $GITHUB_PATH
@@ -61,7 +62,7 @@ jobs:
           bit snap --build
           bit artifacts percona.apps/everest --out-dir ./build
           mkdir ${GITHUB_WORKSPACE}/front
-          cp -rf ./build/percona.apps_everest/artifacts/apps/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
+          cp -rvf ./build/percona.apps_everest/artifacts/apps/react-common-js/everest/public/* ${GITHUB_WORKSPACE}/front/
 
       - name: Check out Everest Backend
         uses: actions/checkout@v4
@@ -76,8 +77,18 @@ jobs:
           cp -rf ${GITHUB_WORKSPACE}/front/* ${GITHUB_WORKSPACE}/backend/public/dist/
           cd ${GITHUB_WORKSPACE}/backend
 
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: './backend/go.mod'
+
+      - name: Build Everest
+        run: |
+          cd ${GITHUB_WORKSPACE}/backend
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make build
+
       - name: Setup docker build metadata
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         id: meta
         with:
           images: perconalab/everest
@@ -85,13 +96,13 @@ jobs:
 
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and Push everest RC-image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: backend
           push: true


### PR DESCRIPTION
The RC build works fine on the BE side, it builds a working Everest image. 
So we need to update the FE side workflow to do the same, which this PR does.

After merge the commit is to be cherry-picked to the RC branch. 