### PR TITLE
EVEREST-571-restore-of-a-scheduled-backup: fix name of restore length

### DIFF
--- a/apps/everest/constants.ts
+++ b/apps/everest/constants.ts
@@ -37,4 +37,5 @@ export const BACKUP_STATE_TO_STATUS: Record<string, BackupStatus> = {
 };
 
 export const MAX_DB_CLUSTER_NAME_LENGTH = 22;
-export const MAX_RFC_1123_NAME_LENGTH = 63;
+// export const MAX_RFC_1123_NAME_LENGTH = 63;
+export const MAX_SCHEDULE_NAME_LENGTH = 57;

--- a/apps/everest/hooks/api/restores/useDbClusterRestore.ts
+++ b/apps/everest/hooks/api/restores/useDbClusterRestore.ts
@@ -16,6 +16,7 @@
 import { useMutation, UseMutationOptions } from 'react-query';
 import { createDbClusterRestore } from '../../../api/restores';
 import { useSelectedKubernetesCluster } from '../kubernetesClusters/useSelectedKubernetesCluster';
+import { generateShortUID } from '../../../pages/database-form/steps/first/utils';
 
 export type RestoreFormData = {
   backupName: string;
@@ -32,7 +33,7 @@ export const useDbClusterRestore = (
         apiVersion: 'everest.percona.com/v1alpha1',
         kind: 'DatabaseClusterRestore',
         metadata: {
-          name: `restore-${formData.backupName}`,
+          name: `restore-${generateShortUID()}`,
         },
         spec: {
           dbClusterName,

--- a/apps/everest/pages/db-cluster-details/backups/scheduled-backup-modal/scheduled-backup-modal-form/scheduled-backup-modal-form.types.ts
+++ b/apps/everest/pages/db-cluster-details/backups/scheduled-backup-modal/scheduled-backup-modal-form/scheduled-backup-modal-form.types.ts
@@ -19,7 +19,7 @@ import {
   TimeValue,
   WeekDays,
 } from '../../../../../components/time-selection/time-selection.types';
-import { MAX_RFC_1123_NAME_LENGTH } from '../../../../../constants';
+import { MAX_SCHEDULE_NAME_LENGTH } from '../../../../../constants';
 import { Messages } from '../scheduled-backup-modal.messages';
 
 export enum ScheduleFields {
@@ -41,10 +41,10 @@ export const schema = z.object({
   [ScheduleFields.name]: z
     .string()
     .nonempty()
-    .max(MAX_RFC_1123_NAME_LENGTH, Messages.scheduleName.tooLong)
+    .max(MAX_SCHEDULE_NAME_LENGTH, Messages.scheduleName.tooLong)
     .regex(
       doesNotContainerAnythingButAlphanumericAndDash,
-      `The schedule name should not exceed ${MAX_RFC_1123_NAME_LENGTH} characters.`
+      `The schedule name should not exceed ${MAX_SCHEDULE_NAME_LENGTH} characters.`
     )
     .regex(doesNotEndWithDash, "The name shouldn't end with a hyphen.")
     .regex(


### PR DESCRIPTION
for /v1/kubernetes/d50a8cee-eee7-4405-b898-030a32271261/database-cluster-restores

![image](https://github.com/percona/percona-everest-frontend/assets/90199600/e277738d-1252-4cfa-93ee-c34fc2128091)
