### PR TITLE
EVEREST-107 fix tests CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,9 +143,8 @@ jobs:
           cd ${GITHUB_WORKSPACE}/percona-everest-backend
           make init
           make local-env-up
-          make build-debug
           touch everest-backend.log
-          make run-debug &> everest-backend.log &
+          SECRETS_ROOT_KEY=$(openssl rand -base64 32) make run-debug &> everest-backend.log &
 
       - name: Archive backend log
         if: failure()
@@ -156,6 +155,15 @@ jobs:
 
       - name: Create KIND cluster
         uses: helm/kind-action@v1.8.0
+
+      - name: Wait for EVEREST BE to be available
+        timeout-minutes: 15
+        run: |
+          while ! curl -sSf http://127.0.0.1:8080 > /dev/null; do
+            echo "Waiting for EVEREST BE..."
+            sleep 15
+          done
+          echo "EVEREST BE is available."
 
       - name: Run Provisioning
         run: |


### PR DESCRIPTION
The CI/Tests step was [failing](https://github.com/percona/percona-everest-frontend/actions/runs/6637671072/job/18032456102?pr=138) 

There were two problems:
1. since the BE runs in background it might be not available yet to the time the CI makes requests to it. The same problem occurred in the CLI repo. The solution is the additional step that checks if the BE is available
2. Since we added the secret storage the SECRETS_ROOT_KEY is expected to be configured for the BE runs