### PR TITLE
EVEREST-575-fix-cron-functions: cron expression fix

### DIFF
--- a/apps/everest/components/time-selection/time-selection.utils.ts
+++ b/apps/everest/components/time-selection/time-selection.utils.ts
@@ -55,7 +55,13 @@ export const getCronExpressionFromFormValues = (
   const parsedDay = Number(onDay);
 
   const hour24 =
-    amPm === AmPM.PM ? (parsedHour === 12 ? 0 : parsedHour + 12) : parsedHour;
+    amPm === AmPM.PM
+      ? parsedHour === 12
+        ? parsedHour
+        : parsedHour + 12
+      : parsedHour === 12
+      ? 0
+      : parsedHour;
 
   switch (selectedTime) {
     case TimeValue.hours:
@@ -71,10 +77,9 @@ export const getCronExpressionFromFormValues = (
   }
 };
 
-const getAmPm = (hour: number): AmPM =>
-  hour === 0 || hour > 12 ? AmPM.PM : AmPM.AM;
+const getAmPm = (hour: number): AmPM => (hour >= 12 ? AmPM.PM : AmPM.AM);
 const getHour12 = (hour24: number): number =>
-  hour24 === 12 ? hour24 : hour24 % 12;
+  hour24 === 12 || hour24 === 0 ? 12 : hour24 % 12;
 const getWeekDayByNumber = (weekDay: number): WeekDays =>
   Object.values(WeekDays)[weekDay];
 


### PR DESCRIPTION
EVEREST-575
fixed cron expression (the boundary values of AM and PM were mixed up)
![image](https://github.com/percona/percona-everest-frontend/assets/90199600/843feeb9-1f53-4643-89d1-dd05edc74b2d)

![image](https://github.com/percona/percona-everest-frontend/assets/90199600/2e413d5a-ec81-4c11-a6ac-b3322d942eaf)
