### PR TITLE
EVEREST-570-Scheduled-backups-are-not-appearing: default sort

### DIFF
--- a/apps/everest/pages/db-cluster-details/backups/backups-list/backups-list.tsx
+++ b/apps/everest/pages/db-cluster-details/backups/backups-list/backups-list.tsx
@@ -196,6 +196,14 @@ export const BackupsList = () => {
         noDataMessage={Messages.noData}
         data={backups}
         columns={columns}
+        initialState={{
+          sorting: [
+            {
+              id: 'created',
+              desc: true,
+            },
+          ],
+        }}
         renderTopToolbarCustomActions={() => (
           <MenuButton buttonText={Messages.createBackup}>
             {/* MUI Menu does not like fragments and asks for arrays instead */}


### PR DESCRIPTION
EVEREST-570
default sort for backups list added
![image](https://github.com/percona/percona-everest-frontend/assets/90199600/df50a1b2-c0de-4e54-adf3-6861a7d9f6c2)
