### PR TITLE
EVEREST-610 Fixed CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Run Provisioning
         run: |
           cd CLI
-          go run cmd/everest/main.go install operators --monitoring.enable=false --name=minikube --operator.mongodb=true --operator.postgresql=true --operator.xtradb-cluster=true --skip-wizard --namespace percona-everest
+          go run cmd/everest/main.go install --monitoring.enable=false --name=minikube --operator.mongodb=true --operator.postgresql=true --operator.xtradb-cluster=true --skip-wizard --namespace percona-everest
 
       - name: Expose Everest backend
         run: |


### PR DESCRIPTION
Once https://github.com/percona/percona-everest-cli/pull/205 is merged the install operators command will be deprecated. 