### PR TITLE
EVEREST-658-enabled-disabled-information-is-not-available

### DIFF
--- a/apps/everest/src/components/dots-menu/dots-menu.tsx
+++ b/apps/everest/src/components/dots-menu/dots-menu.tsx
@@ -18,7 +18,11 @@ import MoreHorizOutlinedIcon from '@mui/icons-material/MoreHorizOutlined';
 import { DotsMenuProps } from './dots-menu.types';
 import { useState, MouseEvent, createElement } from 'react';
 
-export const DotsMenu = ({ menuProps, options }: DotsMenuProps) => {
+export const DotsMenu = ({
+  menuProps,
+  options,
+  iconButtonProps,
+}: DotsMenuProps) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
   const handleClick = (event: MouseEvent<HTMLElement>) => {
@@ -36,6 +40,7 @@ export const DotsMenu = ({ menuProps, options }: DotsMenuProps) => {
         id="more-button"
         onClick={handleClick}
         size="small"
+        {...iconButtonProps}
       >
         <MoreHorizOutlinedIcon />
       </IconButton>
@@ -59,6 +64,7 @@ export const DotsMenu = ({ menuProps, options }: DotsMenuProps) => {
             sx={{
               gap: 1,
             }}
+            disabled={!!item?.disabled}
           >
             {item.icon && createElement(item.icon, { fontSize: 'small' })}
             {item.children}

--- a/apps/everest/src/components/dots-menu/dots-menu.types.ts
+++ b/apps/everest/src/components/dots-menu/dots-menu.types.ts
@@ -1,5 +1,5 @@
 import { SvgIconComponent } from '@mui/icons-material';
-import { MenuProps, MenuItemProps } from '@mui/material';
+import { MenuProps, MenuItemProps, IconButtonProps } from '@mui/material';
 
 export interface Option extends MenuItemProps {
   onClick: () => void;
@@ -9,4 +9,5 @@ export interface DotsMenuProps {
   menuProps?: MenuProps;
   options: Array<Option>;
   handleClose?: () => void;
+  iconButtonProps?: IconButtonProps;
 }

--- a/apps/everest/src/pages/db-cluster-details/backups/backups-list/backups-list.messages.ts
+++ b/apps/everest/src/pages/db-cluster-details/backups/backups-list/backups-list.messages.ts
@@ -16,7 +16,7 @@ export const Messages = {
       'Are you sure you want to replicate the selected database? This will create an exact copy of the current instance.',
     submitButton: 'Create',
   },
-  noData: "You don't have any backups yet. Create one to get started",
+  noData: "You don't have any backups yet. Create one to get started.",
   createBackup: 'Create backup',
   now: 'Now',
   schedule: 'Schedule',

--- a/apps/everest/src/pages/db-cluster-details/backups/backups.messages.ts
+++ b/apps/everest/src/pages/db-cluster-details/backups/backups.messages.ts
@@ -14,15 +14,9 @@
 // limitations under the License.
 
 export const Messages = {
-  sectionHeader: (schedulesNumber: number) =>
-    `${schedulesNumber} ${schedulesNumber > 1 ? 'schedules' : 'schedule'}`,
-  noSchedules: 'No schedules',
-  menuItems: {
-    edit: 'Edit',
-    delete: 'Delete',
-  },
-  deleteModal: {
-    header: 'Delete schedule',
-    content: 'Are you sure you want to permanently delete this schedule?',
-  },
+  // TODO Temporary message. Should be deleted after active/inactive status for each schedule
+  backupsDisabled:
+    'Backups are currently disabled for this database. To set up backup schedules, first re-enable backups in the database configuration.',
+  backupsDisabledPG:
+    'Scheduled backups are currently unavailable for PostgreSQL databases. You can still enable on-demand backups from this page.',
 };

--- a/apps/everest/src/pages/db-cluster-details/backups/backups.tsx
+++ b/apps/everest/src/pages/db-cluster-details/backups/backups.tsx
@@ -22,6 +22,8 @@ import { BackupsList } from './backups-list/backups-list';
 import { ScheduledBackupModal } from './scheduled-backup-modal/scheduled-backup-modal';
 import { ScheduledBackupsList } from './scheduled-backups-list/scheduled-backups-list';
 import { ScheduleModalContext } from './backups.context.ts';
+import { Alert } from '@mui/material';
+import { Messages } from './backups.messages.ts';
 
 export const Backups = () => {
   const { dbClusterName } = useParams();
@@ -55,6 +57,13 @@ export const Backups = () => {
     >
       {dbNameExists && (
         <>
+          {!dbCluster?.spec?.backup?.enabled && (
+            <Alert severity="info">
+              {dbType === DbEngineType.POSTGRESQL
+                ? Messages.backupsDisabledPG
+                : Messages.backupsDisabled}
+            </Alert>
+          )}
           {dbType !== DbEngineType.POSTGRESQL && <ScheduledBackupsList />}
           <BackupsList />
           {openScheduleModal && <ScheduledBackupModal />}

--- a/apps/everest/src/pages/db-cluster-details/backups/scheduled-backups-list/scheduled-backups-list.tsx
+++ b/apps/everest/src/pages/db-cluster-details/backups/scheduled-backups-list/scheduled-backups-list.tsx
@@ -108,18 +108,16 @@ export const ScheduledBackupsList = () => {
   return (
     <>
       {schedules && schedules?.length > 0 && (
-        <Accordion sx={{ mt: 1 }} disabled={!data?.spec?.backup?.enabled}>
+        <Accordion sx={{ mt: 1 }}>
           <AccordionSummary
             expandIcon={<ExpandMoreIcon />}
             aria-controls="scheduled-backups-content"
             data-testid="scheduled-backups"
           >
             <Typography variant="body1">
-              {data?.spec?.backup?.enabled
-                ? schedules
-                  ? Messages.sectionHeader(schedules?.length)
-                  : Messages.noSchedules
-                : Messages.backupsDisabled}
+              {schedules
+                ? Messages.sectionHeader(schedules?.length)
+                : Messages.noSchedules}
             </Typography>
           </AccordionSummary>
           <AccordionDetails>
@@ -159,7 +157,12 @@ export const ScheduledBackupsList = () => {
                         }}
                         data-testid="schedule-dots-menu"
                       >
-                        <DotsMenu options={options(item?.name)} />
+                        <DotsMenu
+                          options={options(item?.name)}
+                          iconButtonProps={{
+                            disabled: !data?.spec?.backup?.enabled,
+                          }}
+                        />
                       </Box>
                     </Box>
                   </Paper>


### PR DESCRIPTION
![image](https://github.com/percona/percona-everest-frontend/assets/90199600/da554d23-ecb0-46d7-aaf4-41fa88514798)

![image](https://github.com/percona/percona-everest-frontend/assets/90199600/41deb190-3e77-4504-859c-9172bf3e9d8f)

- The message that backup Disabled now appears for all databases and not only for MySQL, MongoDB on the backups page
- instead of blocking the entire accordion with the schedules list, we block only the actions button, which allows user to edit or delete the schedule
- the text of the messages has been corrected