### PR TITLE
EVEREST-662-single-scheduled-backup-gets-reset-to-default

### DIFF
--- a/apps/everest/.e2e/db-cluster/db-wizard/edit-db-cluster/resources-step.e2e.ts
+++ b/apps/everest/.e2e/db-cluster/db-wizard/edit-db-cluster/resources-step.e2e.ts
@@ -43,9 +43,7 @@ test.describe('DB Cluster Editing Resources Step (Mongo)', () => {
       await closeIcon.click();
     }
 
-    await findDbAndClickActions(page, mongoDBName);
-
-    await page.getByRole('menuitem', { name: 'Edit' }).click();
+    await findDbAndClickActions(page, mongoDBName, 'Edit');
 
     const nextStep = page.getByTestId('db-wizard-continue-button');
     // Go to Resources step

--- a/apps/everest/.e2e/db-cluster/db-wizard/edit-db-cluster/schedules-step.e2e.ts
+++ b/apps/everest/.e2e/db-cluster/db-wizard/edit-db-cluster/schedules-step.e2e.ts
@@ -104,4 +104,58 @@ test.describe.serial('DB Cluster Editing Backups Step', () => {
 
     expect(page.getByText('Every hour at minute 0')).toBeTruthy();
   });
+
+  test('Disabling/Enabling backups for single scheduled db', async ({
+                                                       page,
+  }) => {
+    await page.goto('/databases');
+    const closeIcon = page.getByTestId('close-dialog-icon');
+    if (closeIcon) {
+      await closeIcon.click();
+    }
+
+    await findDbAndClickActions(page, mySQLName);
+
+    await page.getByRole('menuitem', { name: 'Edit' }).click();
+
+    const nextStep = page.getByTestId('db-wizard-continue-button');
+    // Go to Resources step
+    await nextStep.click();
+    // Go to Backups step
+    await nextStep.click();
+
+    // disabling backups
+    const enabledBackupsCheckbox = page
+        .getByTestId('switch-input-backups-enabled')
+        .getByRole('checkbox');
+    await expect(enabledBackupsCheckbox).toBeChecked();
+    await enabledBackupsCheckbox.setChecked(false);
+    await expect(enabledBackupsCheckbox).not.toBeChecked();
+
+    // checking the preview empty value
+    expect(page.getByTestId('section-Backups').getByTestId('empty-backups-preview-content')).toBeTruthy();
+
+    // Go to Advanced Configuration step
+    await nextStep.click();
+    // Go to Monitoring step
+    await nextStep.click();
+
+    await checkDbWizardEditSubmitIsAvailableAndClick(page);
+    await checkSuccessOfUpdateAndGoToDbClustersList(page);
+
+    await findDbAndClickActions(page, mySQLName);
+    await page.getByRole('menuitem', { name: 'Edit' }).click();
+
+    // Go to Resources step
+    await nextStep.click();
+    // Go to Backups step
+    await nextStep.click();
+
+    // check that schedule hasn't been reset
+    await expect(enabledBackupsCheckbox).not.toBeChecked();
+    await enabledBackupsCheckbox.setChecked(true);
+    await expect(page.getByTestId(
+        'text-input-schedule-name'
+    )).toHaveValue(scheduleName);
+  });
 });

--- a/apps/everest/.e2e/db-cluster/db-wizard/edit-db-cluster/schedules-step.e2e.ts
+++ b/apps/everest/.e2e/db-cluster/db-wizard/edit-db-cluster/schedules-step.e2e.ts
@@ -53,9 +53,7 @@ test.describe.serial('DB Cluster Editing Backups Step', () => {
       await closeIcon.click();
     }
 
-    await findDbAndClickActions(page, mySQLName);
-
-    await page.getByRole('menuitem', { name: 'Edit' }).click();
+    await findDbAndClickActions(page, mySQLName, 'Edit');
 
     const nextStep = page.getByTestId('db-wizard-continue-button');
     // Go to Resources step
@@ -114,9 +112,7 @@ test.describe.serial('DB Cluster Editing Backups Step', () => {
       await closeIcon.click();
     }
 
-    await findDbAndClickActions(page, mySQLName);
-
-    await page.getByRole('menuitem', { name: 'Edit' }).click();
+    await findDbAndClickActions(page, mySQLName, 'Edit');
 
     const nextStep = page.getByTestId('db-wizard-continue-button');
     // Go to Resources step
@@ -147,8 +143,7 @@ test.describe.serial('DB Cluster Editing Backups Step', () => {
     await checkDbWizardEditSubmitIsAvailableAndClick(page);
     await checkSuccessOfUpdateAndGoToDbClustersList(page);
 
-    await findDbAndClickActions(page, mySQLName);
-    await page.getByRole('menuitem', { name: 'Edit' }).click();
+    await findDbAndClickActions(page, mySQLName, 'Edit');
 
     // Go to Resources step
     await nextStep.click();
@@ -161,5 +156,10 @@ test.describe.serial('DB Cluster Editing Backups Step', () => {
     await expect(page.getByTestId('text-input-schedule-name')).toHaveValue(
       scheduleName
     );
+
+    // checking the preview actual value
+    await expect(
+      page.getByTestId('section-Backups').getByTestId('preview-content')
+    ).toHaveText('Every hour at minute 0');
   });
 });

--- a/apps/everest/.e2e/db-cluster/db-wizard/edit-db-cluster/schedules-step.e2e.ts
+++ b/apps/everest/.e2e/db-cluster/db-wizard/edit-db-cluster/schedules-step.e2e.ts
@@ -106,7 +106,7 @@ test.describe.serial('DB Cluster Editing Backups Step', () => {
   });
 
   test('Disabling/Enabling backups for single scheduled db', async ({
-                                                       page,
+    page,
   }) => {
     await page.goto('/databases');
     const closeIcon = page.getByTestId('close-dialog-icon');
@@ -126,14 +126,18 @@ test.describe.serial('DB Cluster Editing Backups Step', () => {
 
     // disabling backups
     const enabledBackupsCheckbox = page
-        .getByTestId('switch-input-backups-enabled')
-        .getByRole('checkbox');
+      .getByTestId('switch-input-backups-enabled')
+      .getByRole('checkbox');
     await expect(enabledBackupsCheckbox).toBeChecked();
     await enabledBackupsCheckbox.setChecked(false);
     await expect(enabledBackupsCheckbox).not.toBeChecked();
 
     // checking the preview empty value
-    expect(page.getByTestId('section-Backups').getByTestId('empty-backups-preview-content')).toBeTruthy();
+    expect(
+      page
+        .getByTestId('section-Backups')
+        .getByTestId('empty-backups-preview-content')
+    ).toBeTruthy();
 
     // Go to Advanced Configuration step
     await nextStep.click();
@@ -154,8 +158,8 @@ test.describe.serial('DB Cluster Editing Backups Step', () => {
     // check that schedule hasn't been reset
     await expect(enabledBackupsCheckbox).not.toBeChecked();
     await enabledBackupsCheckbox.setChecked(true);
-    await expect(page.getByTestId(
-        'text-input-schedule-name'
-    )).toHaveValue(scheduleName);
+    await expect(page.getByTestId('text-input-schedule-name')).toHaveValue(
+      scheduleName
+    );
   });
 });

--- a/apps/everest/.e2e/utils/db-clusters-list.ts
+++ b/apps/everest/.e2e/utils/db-clusters-list.ts
@@ -29,7 +29,11 @@ export const findDbAndClickRow = async (page: Page, dbName: string) => {
   await dbRow.click();
 };
 
-export const findDbAndClickActions = async (page: Page, dbName: string) => {
+export const findDbAndClickActions = async (
+  page: Page,
+  dbName: string,
+  nameOfAction?: string
+) => {
   page.getByTestId(`${dbName}-status`).filter({ hasText: 'Initializing' });
 
   // cluster actions menu click
@@ -38,4 +42,8 @@ export const findDbAndClickActions = async (page: Page, dbName: string) => {
     .filter({ hasText: dbName })
     .getByTestId('MoreHorizIcon')
     .click();
+
+  if (nameOfAction) {
+    await page.getByRole('menuitem', { name: nameOfAction }).click();
+  }
 };

--- a/apps/everest/src/pages/database-form/database-form.utils.ts
+++ b/apps/everest/src/pages/database-form/database-form.utils.ts
@@ -31,8 +31,8 @@ import {
   TIME_SELECTION_DEFAULTS,
 } from './database-form.constants.ts';
 
-const getScheduleInfo = (backup?: Backup) => {
-  if (backup?.enabled) {
+const getScheduleInfo = (mode: DbWizardMode, backup?: Backup) => {
+  if (backup?.enabled && mode==='new' || mode==='edit') {
     const schedules = backup?.schedules;
     const firstSchedule = schedules && schedules[0];
     if (firstSchedule?.schedule && !!schedules && schedules?.length <= 1) {
@@ -55,7 +55,7 @@ export const DbClusterPayloadToFormValues = (
   dbCluster: DbCluster,
   mode: DbWizardMode
 ): DbWizardType => {
-  const scheduleInfo = getScheduleInfo(dbCluster?.spec?.backup); // EVEREST-334
+  const scheduleInfo = getScheduleInfo(mode, dbCluster?.spec?.backup);
 
   return {
     [DbWizardFormFields.backupsEnabled]: !!dbCluster?.spec?.backup?.enabled,

--- a/apps/everest/src/pages/database-form/database-form.utils.ts
+++ b/apps/everest/src/pages/database-form/database-form.utils.ts
@@ -32,7 +32,7 @@ import {
 } from './database-form.constants.ts';
 
 const getScheduleInfo = (mode: DbWizardMode, backup?: Backup) => {
-  if (backup?.enabled && mode==='new' || mode==='edit') {
+  if ((backup?.enabled && mode === 'new') || mode === 'edit') {
     const schedules = backup?.schedules;
     const firstSchedule = schedules && schedules[0];
     if (firstSchedule?.schedule && !!schedules && schedules?.length <= 1) {

--- a/apps/everest/src/pages/database-form/database-preview/database-preview.types.ts
+++ b/apps/everest/src/pages/database-form/database-preview/database-preview.types.ts
@@ -31,4 +31,5 @@ export type PreviewSectionProps = {
 
 export type PreviewContentTextProps = {
   text: string;
+  dataTestId?: string;
 };

--- a/apps/everest/src/pages/database-form/database-preview/preview-section.tsx
+++ b/apps/everest/src/pages/database-form/database-preview/preview-section.tsx
@@ -23,7 +23,7 @@ export const PreviewSection = ({
 
   return (
     <Stack
-      data-testid={`section-${order}`}
+      data-testid={`section-${title}`}
       sx={{
         pl: 3,
         pt: 1,
@@ -80,8 +80,8 @@ export const PreviewSection = ({
   );
 };
 
-export const PreviewContentText = ({ text }: PreviewContentTextProps) => (
-  <Typography variant="caption" color="text.secondary">
+export const PreviewContentText = ({ text, dataTestId }: PreviewContentTextProps) => (
+  <Typography variant="caption" color="text.secondary" data-testid={dataTestId? `${dataTestId}-preview-content`: 'preview-content'} >
     {text}
   </Typography>
 );

--- a/apps/everest/src/pages/database-form/database-preview/preview-section.tsx
+++ b/apps/everest/src/pages/database-form/database-preview/preview-section.tsx
@@ -80,8 +80,17 @@ export const PreviewSection = ({
   );
 };
 
-export const PreviewContentText = ({ text, dataTestId }: PreviewContentTextProps) => (
-  <Typography variant="caption" color="text.secondary" data-testid={dataTestId? `${dataTestId}-preview-content`: 'preview-content'} >
+export const PreviewContentText = ({
+  text,
+  dataTestId,
+}: PreviewContentTextProps) => (
+  <Typography
+    variant="caption"
+    color="text.secondary"
+    data-testid={
+      dataTestId ? `${dataTestId}-preview-content` : 'preview-content'
+    }
+  >
     {text}
   </Typography>
 );

--- a/apps/everest/src/pages/database-form/database-preview/sections/backups-section.tsx
+++ b/apps/everest/src/pages/database-form/database-preview/sections/backups-section.tsx
@@ -41,7 +41,9 @@ export const BackupsPreviewSection = (backupsSection: BackupStepType) => {
         mode === 'edit' &&
         schedules?.length > 1 &&
         schedulesPreviewList.map((item) => <PreviewContentText text={item} />)}
-      {!backupsEnabled && <PreviewContentText text="-" dataTestId="empty-backups" />}
+      {!backupsEnabled && (
+        <PreviewContentText text="-" dataTestId="empty-backups" />
+      )}
     </>
   );
 };

--- a/apps/everest/src/pages/database-form/database-preview/sections/backups-section.tsx
+++ b/apps/everest/src/pages/database-form/database-preview/sections/backups-section.tsx
@@ -41,7 +41,7 @@ export const BackupsPreviewSection = (backupsSection: BackupStepType) => {
         mode === 'edit' &&
         schedules?.length > 1 &&
         schedulesPreviewList.map((item) => <PreviewContentText text={item} />)}
-      {!backupsEnabled && <PreviewContentText text="-" />}
+      {!backupsEnabled && <PreviewContentText text="-" dataTestId="empty-backups" />}
     </>
   );
 };


### PR DESCRIPTION
EVEREST-662 solved problem: when user disabled the scheduled backups option in dbWizard and then enabled this option, schedule values were not setting to the form as default values

[EVEREST-662.webm](https://github.com/percona/percona-everest-frontend/assets/90199600/a846f0d5-de38-4dfe-95db-b4032bef6802)
