### PR TITLE
select-input-wrapper: fix no options for select

### DIFF
--- a/packages/ui-lib/src/form/inputs/select/select.messages.ts
+++ b/packages/ui-lib/src/form/inputs/select/select.messages.ts
@@ -12,17 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { LabeledContentProps } from '../../../labeled-content';
-import { SelectProps } from '@mui/material';
-import { Control, UseControllerProps } from 'react-hook-form';
 
-export type SelectInputProps = {
-  control?: Control;
-  controllerProps?: UseControllerProps;
-  name: string;
-  label?: string;
-  labelProps?: LabeledContentProps;
-  selectFieldProps?: SelectProps;
-  children?: React.ReactNode[];
-  isRequired?: boolean;
+export const Messages = {
+  noOptions: 'No options',
 };

--- a/packages/ui-lib/src/form/inputs/select/select.tsx
+++ b/packages/ui-lib/src/form/inputs/select/select.tsx
@@ -1,8 +1,9 @@
-import { Select } from '@mui/material';
+import { MenuItem, Select } from '@mui/material';
 import { kebabize } from '@percona/utils';
 import { Controller, useFormContext } from 'react-hook-form';
 import { SelectInputProps } from './select.types';
 import LabeledContent from '../../../labeled-content';
+import { Messages } from './select.messages';
 
 const SelectInput = ({
   name,
@@ -15,6 +16,7 @@ const SelectInput = ({
   isRequired = false,
 }: SelectInputProps) => {
   const { control: contextControl } = useFormContext();
+  console.log(children);
   const content = (
     <Controller
       name={name}
@@ -32,6 +34,22 @@ const SelectInput = ({
           {...selectFieldProps}
         >
           {children}
+          {(!children || children?.length === 0) && (
+            <MenuItem
+              disabled
+              key="noOptions"
+              value=""
+              data-testId="no-options-select"
+              sx={{
+                fontWeight: '400',
+                '&.Mui-disabled.Mui-selected': {
+                  backgroundColor: 'transparent',
+                },
+              }}
+            >
+              {Messages.noOptions}
+            </MenuItem>
+          )}
         </Select>
       )}
       {...controllerProps}


### PR DESCRIPTION
![image](https://github.com/percona/percona-everest-frontend/assets/90199600/120c2909-7abb-4113-bdf6-a3b7512ac335)

![image](https://github.com/percona/percona-everest-frontend/assets/90199600/c6bd45f5-8dc1-40e0-a2a3-19f4da220e68)

![image](https://github.com/percona/percona-everest-frontend/assets/90199600/ca671bc3-326f-4eff-8254-59d4d6c042a8)
